### PR TITLE
Only count ping replies of type 0 as valid ping replies

### DIFF
--- a/Tools/myping/myping.cpp
+++ b/Tools/myping/myping.cpp
@@ -195,7 +195,7 @@ int CheckIcmpReplyHeader(char *buf, int bytes)
         return icmphdr->icmp_type;
     }
 
-    return 0;
+    return -1;
 }
 
 //

--- a/Tools/myping/myping.cpp
+++ b/Tools/myping/myping.cpp
@@ -191,8 +191,8 @@ int CheckIcmpReplyHeader(char *buf, int bytes)
             return 3;
         }
 
-		printf("\n Reply type - Unknown");
-		return icmphdr->icmp_type;
+        printf("\n Reply type - Unknown");
+        return icmphdr->icmp_type;
     }
 
     return 0;

--- a/Tools/myping/myping.cpp
+++ b/Tools/myping/myping.cpp
@@ -190,6 +190,9 @@ int CheckIcmpReplyHeader(char *buf, int bytes)
             printf("\n Reply type - Host not reachable");				
             return 3;
         }
+
+		printf("\n Reply type - Unknown");
+		return icmphdr->icmp_type;
     }
 
     return 0;
@@ -944,7 +947,7 @@ int __cdecl main(int argc, char **argv)
                     Sleep(gWaitTime-time); // sleep for the remaining wait time
             }
             
-            if ( 3 != CheckIcmpReplyHeader(recvbuf, bytes))
+            if (0 == CheckIcmpReplyHeader(recvbuf, bytes)) // if reply type is 0 - Echo Reply then count it
             {
                 recd++;
             }


### PR DESCRIPTION
myping will count replies of type 11 (Time Exceeded) as well as other rare cases as valid pings.  It is probably safer to just only count replies with the type set to 0 (Echo Reply) as valid pings.